### PR TITLE
Added "from" field to shared app group data

### DIFF
--- a/LibreDirect/Modules/AppGroupSharing/AppGroupSharing.swift
+++ b/LibreDirect/Modules/AppGroupSharing/AppGroupSharing.swift
@@ -60,7 +60,8 @@ private extension Glucose {
             "Value": glucoseValue,
             "Trend": trend.toFreeAPS(),
             "DT": date,
-            "direction": trend.toFreeAPSX()
+            "direction": trend.toFreeAPSX(),
+            "from": "GlucoseDirect"
         ]
 
         return freeAPSGlucose


### PR DESCRIPTION
If GlucoseDirect and XDrip applications are used at the same time , FreeAPS X cannot distinguish the data from them, resulting in unpredictable behavior. Added `from` field  so that the FAX can understand the glucose source.

xDrip PR https://github.com/JohanDegraeve/xdripswift/pull/290