### PR TITLE
Feature/custom alarm interval

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -45,6 +45,7 @@ struct AppState: DirectState {
         self.alarmHigh = UserDefaults.standard.alarmHigh
         self.alarmLow = UserDefaults.standard.alarmLow
         self.alarmVolume = UserDefaults.standard.alarmVolume
+        self.alarmInterval = UserDefaults.standard.alarmInterval
         self.appleCalendarExport = UserDefaults.standard.appleCalendarExport
         self.appleHealthExport = UserDefaults.standard.appleHealthExport
         self.bellmanAlarm = UserDefaults.standard.bellmanAlarm
@@ -114,6 +115,7 @@ struct AppState: DirectState {
     var alarmHigh: Int { didSet { UserDefaults.standard.alarmHigh = alarmHigh } }
     var alarmLow: Int { didSet { UserDefaults.standard.alarmLow = alarmLow } }
     var alarmVolume: Float { didSet { UserDefaults.standard.alarmVolume = alarmVolume } }
+    var alarmInterval: Int { didSet { UserDefaults.standard.alarmInterval = alarmInterval } }
     var appleCalendarExport: Bool { didSet { UserDefaults.standard.appleCalendarExport = appleCalendarExport } }
     var appleHealthExport: Bool { didSet { UserDefaults.standard.appleHealthExport = appleHealthExport } }
     var bellmanAlarm: Bool { didSet { UserDefaults.standard.bellmanAlarm = bellmanAlarm } }

--- a/App/Modules/GlucoseNotification/GlucoseNotification.swift
+++ b/App/Modules/GlucoseNotification/GlucoseNotification.swift
@@ -47,7 +47,7 @@ private func glucoseNotificationMiddelware(service: LazyService<GlucoseNotificat
                         service.value.setLowGlucoseAlarm(sound: state.lowGlucoseAlarmSound, volume: state.alarmVolume, ignoreMute: state.ignoreMute)
                     }
 
-                    return Just(.setAlarmSnoozeUntil(untilDate: Date().addingTimeInterval(5 * 60).toRounded(on: 1, .minute), autosnooze: true))
+                    return Just(.setAlarmSnoozeUntil(untilDate: Date().addingTimeInterval(Double(state.alarmInterval) * 60).toRounded(on: 1, .minute), autosnooze: true))
                         .setFailureType(to: DirectError.self)
                         .eraseToAnyPublisher()
                 }
@@ -64,7 +64,7 @@ private func glucoseNotificationMiddelware(service: LazyService<GlucoseNotificat
                         service.value.setHighGlucoseAlarm(sound: state.highGlucoseAlarmSound, volume: state.alarmVolume, ignoreMute: state.ignoreMute)
                     }
 
-                    return Just(.setAlarmSnoozeUntil(untilDate: Date().addingTimeInterval(5 * 60).toRounded(on: 1, .minute), autosnooze: true))
+                    return Just(.setAlarmSnoozeUntil(untilDate: Date().addingTimeInterval(Double(state.alarmInterval) * 60).toRounded(on: 1, .minute), autosnooze: true))
                         .setFailureType(to: DirectError.self)
                         .eraseToAnyPublisher()
                 }

--- a/App/Views/Settings/AlarmSettingsView.swift
+++ b/App/Views/Settings/AlarmSettingsView.swift
@@ -52,10 +52,10 @@ struct AlarmSettingsView: View {
                     HStack {
                         Text("Alarm interval")
                         Spacer()
-                        Text(store.state.alarmInterval.description + " mins")
+                        Text(String(format: LocalizedString("%1$@ minutes"), store.state.alarmInterval.description))
                     }
                     
-                    Slider(value: alarmInterval, in: 2...15, step: 1)
+                    Slider(value: alarmInterval, in: 2...20, step: 1)
                 }
 
                 Toggle("Ignore mute", isOn: ignoreMute).toggleStyle(SwitchToggleStyle(tint: Color.ui.accent))

--- a/App/Views/Settings/AlarmSettingsView.swift
+++ b/App/Views/Settings/AlarmSettingsView.swift
@@ -48,6 +48,15 @@ struct AlarmSettingsView: View {
                     
                     Slider(value: alarmVolume, in: 0...1, step: 0.05)
                 }
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text("Alarm interval")
+                        Spacer()
+                        Text(store.state.alarmInterval.description + " mins")
+                    }
+                    
+                    Slider(value: alarmInterval, in: 2...15, step: 1)
+                }
 
                 Toggle("Ignore mute", isOn: ignoreMute).toggleStyle(SwitchToggleStyle(tint: Color.ui.accent))
             },
@@ -77,6 +86,15 @@ struct AlarmSettingsView: View {
                 } else {
                     DirectNotifications.shared.testSound(sound: .alarm, volume: $0)
                 }
+            }
+        )
+    }
+    
+    private var alarmInterval: Binding<Float> {
+        Binding(
+            get: { Float(store.state.alarmInterval) },
+            set: {
+                store.dispatch(.setAlarmInterval(interval: Int($0)))
             }
         )
     }

--- a/Library/DirectAction.swift
+++ b/Library/DirectAction.swift
@@ -51,6 +51,7 @@ enum DirectAction {
     case setAppIsBusy(isBusy: Bool)
     case setIgnoreMute(enabled: Bool)
     case setAlarmHigh(upperLimit: Int)
+    case setAlarmInterval(interval: Int)
     case setAlarmLow(lowerLimit: Int)
     case setAlarmVolume(volume: Float)
     case setAlarmSnoozeUntil(untilDate: Date?, autosnooze: Bool = false)

--- a/Library/DirectReducer.swift
+++ b/Library/DirectReducer.swift
@@ -100,7 +100,10 @@ func directReducer(state: inout DirectState, action: DirectAction) {
         
     case .setAlarmVolume(volume: let volume):
         state.alarmVolume = volume
-        
+    
+    case .setAlarmInterval(interval: let interval):
+        state.alarmInterval = interval
+    
     case .setAlarmSnoozeUntil(untilDate: let untilDate, autosnooze: let autosnooze):
         if let untilDate = untilDate {
             state.alarmSnoozeUntil = untilDate

--- a/Library/DirectState.swift
+++ b/Library/DirectState.swift
@@ -15,6 +15,7 @@ protocol DirectState {
     var appState: ScenePhase { get set }
     var alarmHigh: Int { get set }
     var alarmLow: Int { get set }
+    var alarmInterval: Int { get set }
     var alarmSnoozeUntil: Date? { get set }
     var alarmSnoozeKind: Alarm? { get set }
     var alarmVolume: Float { get set }

--- a/Library/Extensions/UserDefaults.swift
+++ b/Library/Extensions/UserDefaults.swift
@@ -12,6 +12,7 @@ private enum Keys: String {
     case alarmHigh = "libre-direct.settings.alarm-high"
     case alarmLow = "libre-direct.settings.alarm-low"
     case alarmVolume = "libre-direct.settings.alarm-volume"
+    case alarmInterval = "libre-direct.settings.alarm-interval"
     case appleHealthExport = "libre-direct.settings.apple-health-export"
     case bellmanAlarm = "libre-direct.settings.bellman-alarm"
     case calendarExport = "libre-direct.settings.calendar-export"
@@ -106,6 +107,19 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Keys.alarmVolume.rawValue)
+        }
+    }
+    
+    var alarmInterval: Int {
+        get {
+            if object(forKey: Keys.alarmInterval.rawValue) != nil {
+                return integer(forKey: Keys.alarmInterval.rawValue)
+            }
+
+            return 5
+        }
+        set {
+            set(newValue, forKey: Keys.alarmInterval.rawValue)
         }
     }
 

--- a/Library/bg.lproj/Localizable.strings
+++ b/Library/bg.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Сила на звука на алармата";
 
 /* (No Comment) */
+"Alarm interval" = "Интервал на алармата";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Коефициентът на вариация (Coefficient of variation - CV) се определя като отношение на стандартното отклонение към средната стойност. Най-общо казано, повечето експерти искат да видят CV от 33% или по-нисък, което се счита за маркер за \"стабилни\" нива на глюкозата. Но имайте предвид, че много от младите пациенти с диабет са склонни да имат по-висока вариабилност (variability), отколкото възрастните.";

--- a/Library/de.lproj/Localizable.strings
+++ b/Library/de.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarmlautstärke";
 
 /* (No Comment) */
+"Alarm interval" = "Alarmintervall";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Der Koeffizient der Variation (CV) ist definiert als das Verhältnis der Standardabweichung zum Mittelwert. Im Allgemeinen bevorzugen die meisten Experten einen CV von 33% oder niedriger, was als Indikator für \"stabile\" Blutzuckerwerte gilt. Beachten Sie jedoch, dass sehr junge Patienten mit Diabetes tendenziell eine höhere Variabilität aufweisen als Erwachsene.";

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Alarm interval";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/es.lproj/Localizable.strings
+++ b/Library/es.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Volumen de la alarma";
 
 /* (No Comment) */
+"Alarm interval" = "Intervalo de la alarma";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "El coeficiente de variación (CV) se define como la relación entre la desviación típica y la media. En general, la mayoría de los expertos desean ver un CV del 33 % o inferior, lo que se considera un marcador de niveles de glucosa \"estables\". Sin embargo, hay que tener en cuenta que los pacientes diabéticos muy jóvenes tienden a presentar una mayor variabilidad que los adultos.";

--- a/Library/fi.lproj/Localizable.strings
+++ b/Library/fi.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Hälytysväli";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/fr.lproj/Localizable.strings
+++ b/Library/fr.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Volume de l'alarme";
 
 /* (No Comment) */
+"Alarm interval" = "Intervalle de l'alarme";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Le coefficient de variation (CV) est défini comme le rapport de l'écart type à la moyenne. De manière générale, la plupart des experts aiment voir un CV de 33 % ou moins, ce qui est considéré comme un marqueur de taux de glucose « stable ». Mais notez que les très jeunes patients atteints de diabète ont tendance à avoir une variabilité plus élevée que les adultes.";

--- a/Library/it.lproj/Localizable.strings
+++ b/Library/it.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Intervallo di allarme";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/nl.lproj/Localizable.strings
+++ b/Library/nl.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Alarminterval";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/pl.lproj/Localizable.strings
+++ b/Library/pl.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Głośność alarmu";
 
 /* (No Comment) */
+"Alarm interval" = "Interwał alarmu";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Współczynnik zmienności (CV) jest definiowany jako stosunek odchylenia standardowego do średniej. Wartość CV na poziomie 33% lub niższym jest uważana za marker \"stabilnego\" poziomu glukozy. Uwaga: bardzo młodzi pacjenci z cukrzycą mają tendencję do większej zmienności niż dorośli.";

--- a/Library/pt-PT.lproj/Localizable.strings
+++ b/Library/pt-PT.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Intervalo de alarme";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/ru.lproj/Localizable.strings
+++ b/Library/ru.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Громкость тревожного сигнала";
 
 /* (No Comment) */
+"Alarm interval" = "Интервал тревоги";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Коэффициент вариации (CV) определяется как отношение стандартного отклонения к среднему значению. В общем, большинство специалистов настаивают, что КВ должен быть 33% или ниже, что считается признаком «стабильного» уровня глюкозы. Но обратите внимание, что очень молодые пациенты с диабетом, как правило, имеют более высокую вариабельность, чем взрослые.";

--- a/Library/sv.lproj/Localizable.strings
+++ b/Library/sv.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "Larmintervall";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/tr.lproj/Localizable.strings
+++ b/Library/tr.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm ses seviyesi";
 
 /* (No Comment) */
+"Alarm interval" = "Alarm aralığı";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Varyasyon katsayısı (CV), standart sapmanın ortalamaya oranı olarak tanımlanır. Genel olarak, çoğu uzman %33 veya daha düşük bir CV görmek ister, bu da \"istikrarlı\" glikoz seviyelerinin bir işareti olarak kabul edilir. Ancak, çok genç diyabet hastalarının yetişkinlerden daha yüksek değişkenliğe sahip olma eğiliminde olduğunu dikkate alın.";

--- a/Library/uk.lproj/Localizable.strings
+++ b/Library/uk.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Гучність сигналу попередження";
 
 /* (No Comment) */
+"Alarm interval" = "Інтервал тривоги";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Коефіцієнт мінливості (CV) визначається як відношення стандартного відхилення до середнього значення. Взагалі кажучи, більшість експертів воліють бачити КМ на рівні 33% або нижче, що вважається маркером «стабільного» рівня глюкози. Але зверніть увагу, що дуже молоді пацієнти з діабетом, як правило, мають більш високу мінливість, ніж дорослі.";

--- a/Library/zh-Hans.lproj/Localizable.strings
+++ b/Library/zh-Hans.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "报警间隔";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";

--- a/Library/zh-Hant.lproj/Localizable.strings
+++ b/Library/zh-Hant.lproj/Localizable.strings
@@ -599,4 +599,7 @@
 "Alarm volume" = "Alarm volume";
 
 /* (No Comment) */
+"Alarm interval" = "報警間隔";
+
+/* (No Comment) */
 "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults." = "Coefficient of variation (CV) is defined as the ratio of the standard deviation to the mean. Generally speaking, most experts like to see a CV of 33% or lower, which is considered a marker of “stable” glucose levels. But take note, very young patients with diabetes tend to have higher variability than adults.";


### PR DESCRIPTION
# Description
Sometimes after injecting insulin too late, one expects sugar levels to stay high for a period of time, this feature allows the ability to set a custom alarm interval, instead of the current 5 minutes default. 
This way every user can set his's own preference for a reminder that the sugar levels are still out of bounds.
The default stays at 5, so there are no breaking changes.

## Type of change
-  New feature (non-breaking change which adds functionality)
