### PR TITLE
Solve widget issue iOS17: add containerBackground API support

### DIFF
--- a/Widgets/GlucoseActivityWidget.swift
+++ b/Widgets/GlucoseActivityWidget.swift
@@ -155,6 +155,7 @@ struct DynamicIslandCenterView: View, GlucoseStatusContext {
                     .opacity(0.5)
             }
         }.padding(.bottom)
+        .widgetBackground(backgroundView: Color("WidgetBackground"))
     }
 }
 
@@ -257,6 +258,7 @@ struct GlucoseActivityView: View, GlucoseStatusContext {
         }
         .padding(.top, 5)
         .padding(.bottom, 10)
+        .widgetBackground(backgroundView: Color("WidgetBackground"))
     }
 }
 

--- a/Widgets/GlucoseWidget.swift
+++ b/Widgets/GlucoseWidget.swift
@@ -102,6 +102,7 @@ struct GlucoseView: View {
                             .font(.system(size: 10))
                     }
                 }
+                .widgetBackground(backgroundView: Color("WidgetBackground"))
 
             case .accessoryCircular:
                 VStack(alignment: .center) {
@@ -113,6 +114,7 @@ struct GlucoseView: View {
                     Text(glucose.timestamp.toLocalTime())
                         .font(.system(size: 10))
                 }
+                .widgetBackground(backgroundView: Color("WidgetBackground"))
 
             case .systemSmall:
                 ZStack {
@@ -159,6 +161,7 @@ struct GlucoseView: View {
                         .font(.footnote)
                     }
                 }
+                .widgetBackground(backgroundView: Color("WidgetBackground"))
 
             default:
                 Text("")

--- a/Widgets/SensorWidget.swift
+++ b/Widgets/SensorWidget.swift
@@ -105,7 +105,9 @@ struct SensorView: View {
                     Text(sensor.remainingWarmupTime == nil ? sensor.family.localizedDescription : "Warmup")
                         .font(.system(size: 10))
                 }
-            ).gaugeStyle(.accessoryCircularCapacity)
+            )
+            .gaugeStyle(.accessoryCircularCapacity)
+            .widgetBackground(backgroundView: Color("WidgetBackground"))
         } else {
             ZStack(alignment: .center) {
                 Circle()
@@ -114,6 +116,7 @@ struct SensorView: View {
 
                 Image(systemName: "questionmark")
             }
+            .widgetBackground(backgroundView: Color("WidgetBackground"))
         }
     }
 }

--- a/Widgets/TransmitterWidget.swift
+++ b/Widgets/TransmitterWidget.swift
@@ -80,6 +80,7 @@ struct TransmitterView: View {
                         .font(.system(size: 10))
                 }
             ).gaugeStyle(.accessoryCircularCapacity)
+            .widgetBackground(backgroundView: Color("WidgetBackground"))
         } else {
             ZStack(alignment: .center) {
                 Circle()
@@ -88,6 +89,7 @@ struct TransmitterView: View {
 
                 Image(systemName: "questionmark")
             }
+            .widgetBackground(backgroundView: Color("WidgetBackground"))
         }
     }
 

--- a/Widgets/Widgets.swift
+++ b/Widgets/Widgets.swift
@@ -25,3 +25,15 @@ struct Widgets: WidgetBundle {
         }
     }
 }
+
+extension View {
+    func widgetBackground(backgroundView: some View) -> some View {
+        if #available(watchOS 10.0, iOSApplicationExtension 17.0, iOS 17.0, macOSApplicationExtension 14.0, *) {
+            return containerBackground(for: .widget) {
+                backgroundView
+            }
+        } else {
+            return background(backgroundView)
+        }
+    }
+}


### PR DESCRIPTION
Added support for iOS 17 containerBackground API. 

Based on: https://stackoverflow.com/questions/76595240/widget-on-ios-17-beta-device-adopt-containerbackground-api