### PR TITLE
Support new libre2EU sensor type 0x7F

### DIFF
--- a/App/Modules/SensorConnector/LibreConnection/LibreNFC.swift
+++ b/App/Modules/SensorConnector/LibreConnection/LibreNFC.swift
@@ -178,7 +178,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
                             break
                         }
 
-                        let sensor = Sensor.libreStyleSensor(uuid: sensorUID, patchInfo: patchInfo, fram: fram)
+                        var sensor = Sensor.libreStyleSensor(uuid: sensorUID, patchInfo: patchInfo, fram: fram)
 
                         if let factoryCalibration = sensor.factoryCalibration {
                             let readings = LibreUtility.parseFRAM(calibration: factoryCalibration, pairingTimestamp: sensor.pairingTimestamp, fram: fram)
@@ -192,6 +192,9 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
                                     returnWithError(LibrePairingError.streamingNotEnabled)
                                     return
                                 }
+
+                                let macAddress = Data(streaminResponse.reversed()).hexEncodedString().uppercased()
+                                sensor.macAddress = macAddress
                             }
 
                             returnWithResult(isPaired: true, sensor: sensor, readings: readings.history + readings.trend)

--- a/App/Views/Overview/SensorView.swift
+++ b/App/Views/Overview/SensorView.swift
@@ -114,6 +114,14 @@ struct SensorView: View {
                                 Text(serial.description)
                             }
                         }
+
+                        if let macAddress = sensor.macAddress {
+                            HStack {
+                                Text("MAC address")
+                                Spacer()
+                                Text(macAddress)
+                            }
+                        }
                     },
                     header: {
                         Label("Sensor details", systemImage: "text.magnifyingglass")

--- a/Library/Content/Sensor.swift
+++ b/Library/Content/Sensor.swift
@@ -17,6 +17,7 @@ struct Sensor: Codable {
         uuid = nil
         patchInfo = nil
         factoryCalibration = nil
+        macAddress = nil
 
         self.family = family
         self.type = type
@@ -32,6 +33,7 @@ struct Sensor: Codable {
         pairingTimestamp = Date()
 
         fram = nil
+        macAddress = nil
 
         self.uuid = uuid
         self.patchInfo = patchInfo
@@ -48,6 +50,8 @@ struct Sensor: Codable {
 
     init(fram: Data, uuid: Data, patchInfo: Data, factoryCalibration: FactoryCalibration?, family: SensorFamily, type: SensorType, region: SensorRegion, serial: String?, state: SensorState, age: Int, lifetime: Int, warmupTime: Int = 60) {
         pairingTimestamp = Date()
+
+        macAddress = nil
 
         self.fram = fram
         self.uuid = uuid
@@ -97,6 +101,7 @@ struct Sensor: Codable {
         type = try container.decode(SensorType.self, forKey: .type)
         region = try container.decode(SensorRegion.self, forKey: .region)
         serial = try container.decode(String?.self, forKey: .serial)
+        macAddress = try container.decode(String?.self, forKey: .macAddress)
         state = try container.decode(SensorState.self, forKey: .state)
         age = try container.decode(Int.self, forKey: .age)
         lifetime = try container.decode(Int.self, forKey: .lifetime)
@@ -116,6 +121,7 @@ struct Sensor: Codable {
         case type
         case region
         case serial
+        case macAddress
         case state
         case age
         case lifetime
@@ -132,6 +138,7 @@ struct Sensor: Codable {
     let type: SensorType
     let region: SensorRegion
     let serial: String?
+    var macAddress: String?
     var state: SensorState
     var age: Int
     var lifetime: Int
@@ -154,7 +161,7 @@ struct Sensor: Codable {
     }
 
     var description: String {
-        "{ uuid: \(uuid?.hex ?? "-"), patchInfo: \(patchInfo?.hex ?? "-"), factoryCalibration: \(factoryCalibration), family: \(family), type: \(type), region: \(region), serial: \(serial ?? "-"), state: \(state.description), lifetime: \(lifetime.inTime) }"
+        "{ uuid: \(uuid?.hex ?? "-"), patchInfo: \(patchInfo?.hex ?? "-"), factoryCalibration: \(factoryCalibration), family: \(family), type: \(type), region: \(region), serial: \(serial ?? "-"), macAddress: \(macAddress ?? "-"), state: \(state.description), lifetime: \(lifetime.inTime) }"
     }
 
     var endTimestamp: Date? {

--- a/Library/Content/SensorType.swift
+++ b/Library/Content/SensorType.swift
@@ -33,7 +33,7 @@ enum SensorType: String, Codable {
             self = .libreUS14day
         case 0x70:
             self = .libreProH
-        case 0x9D, 0xC5, 0xC6:
+        case 0x9D, 0xC5, 0xC6, 0x7F:
             self = .libre2EU
         case 0x76:
             self = patchInfo[3] == 0x02 ? .libre2US

--- a/Library/Extensions/Data.swift
+++ b/Library/Extensions/Data.swift
@@ -10,9 +10,18 @@ extension Data {
     var hex: String {
         map { String(format: "%02X", $0) }.joined(separator: " ")
     }
-    
+
     var utf8: String {
         String(decoding: self, as: UTF8.self)
+    }
+
+    private static let hexAlphabet = "0123456789abcdef".unicodeScalars.map { $0 }
+
+    public func hexEncodedString() -> String {
+        String(self.reduce(into: "".unicodeScalars) { result, value in
+            result.append(Data.hexAlphabet[Int(value / 16)])
+            result.append(Data.hexAlphabet[Int(value % 16)])
+        })
     }
 
     init?(hexString: String) {


### PR DESCRIPTION
A new sensor type was found in my new Libre 2+ sensors I applied, they have patch info "127" or `0x7F`. I have added support for this in `SensorType` for the `libre2EU` case. 

Most likely will solve this issue too: #618